### PR TITLE
Remove meta tag content from search map, fixes #5

### DIFF
--- a/src/content-hashes/infrastructure/plugins/html.ts
+++ b/src/content-hashes/infrastructure/plugins/html.ts
@@ -70,7 +70,6 @@ const searchMap: Readonly<Record<string, readonly string[]>> = {
   ins: ['cite'],
   link: ['href'],
   menuitem: ['icon'],
-  meta: ['content'],
   object: ['codebase', 'data'],
   q: ['cite'],
   script: ['src'],


### PR DESCRIPTION
Hello,

I checked out the standard usage of  the ``meta`` tag, it shouldn't be used to reference files, at least in standard scenarios.
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name .

So I propose to remove ``meta`` tag from the search of entries to be hashed, instead of adding more complexity to the code.
Does it sound acceptable?