### PR TITLE
fix: double-check meta tags to be http equivalent

### DIFF
--- a/src/content-hashes/application/hashDirectory.test.ts
+++ b/src/content-hashes/application/hashDirectory.test.ts
@@ -189,7 +189,7 @@ const expected = {
     filePath: 'index.html',
     fileExtension: '.html',
     contents:
-      '<!DOCTYPE html>\n<html>\n\n<head>\n  <title>Tapas</title>\n\n  <link href="./index.jPrPHrTrxlk1.css" />\n</head>\n\n<body>\n  <div id="app"></div>\n\n  <script type="module" src="./index.NWkKj7N8Hd6f.js"></script>\n</body>\n\n</html>\n',
+      '<!DOCTYPE html>\n<html>\n\n<head>\n  <title>Tapas</title>\n\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <link href="./index.jPrPHrTrxlk1.css" />\n</head>\n\n<body>\n  <div id="app"></div>\n\n  <script type="module" src="./index.NWkKj7N8Hd6f.js"></script>\n</body>\n\n</html>\n',
     contentHash: {
       _tag: 'None',
     },
@@ -199,8 +199,8 @@ const expected = {
         filePath: 'index.css',
         fileExtension: '.css',
         position: {
-          start: 69,
-          end: 80,
+          start: 142,
+          end: 153,
         },
       },
       {
@@ -208,8 +208,8 @@ const expected = {
         filePath: 'index.js',
         fileExtension: '.js',
         position: {
-          start: 154,
-          end: 164,
+          start: 227,
+          end: 237,
         },
       },
     ],

--- a/test/index.html
+++ b/test/index.html
@@ -4,6 +4,7 @@
 <head>
   <title>Tapas</title>
 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="./index.css" />
 </head>
 


### PR DESCRIPTION
Possible fix for #5 which avoids meta tags that are not http equivalent, and adds some more defensive logic for determining if the result of `extname` is really an extension or some other string with a `.` with it.