### PR TITLE
Enable support for "exports" in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,6 +1179,15 @@
         "once": "^1.4.0"
       }
     },
+    "enhanced-resolve": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
+      "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      }
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -1771,8 +1780,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growl": {
       "version": "1.10.5",
@@ -3380,6 +3388,11 @@
           "dev": true
         }
       }
+    },
+    "tapable": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+      "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "base64url": "^3.0.1",
     "builtin-modules": "^3.2.0",
     "css-tree": "^1.1.2",
+    "enhanced-resolve": "^5.7.0",
     "fp-ts": "^2.9.3",
     "himalaya": "^1.1.0",
     "magic-string": "^0.25.7",

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@ Options:
       --registryFile      Configure where to write Document Registry to JSON.
                           Useful for debugging                          [string]
       --sourceMaps                                     [boolean] [default: true]
+      --mainFields        Configure package.json fields to look for dependencies
+                                                   [array] [default: ["module"]]
       --help              Show help                                    [boolean]
 ```
 

--- a/src/cli/content-hash.ts
+++ b/src/cli/content-hash.ts
@@ -49,6 +49,11 @@ const options = yargs
     type: 'boolean',
     default: true,
   })
+  .options('mainFields', {
+    type: 'array',
+    default: ['module'],
+    description: 'Configure package.json fields to look for dependencies',
+  })
   .help().argv
 
 function getLogLevel(option: string) {
@@ -76,6 +81,7 @@ contentHashDirectory({
   assetManifest: resolve(directory, options.assetManifest),
   baseUrl: options.baseUrl,
   plugins: createDefaultPlugins({
+    mainFields: options.mainFields,
     buildDirectory: directory,
     compilerOptions: pipe(
       tsConfig,

--- a/src/content-hashes/application/hashDirectory.test.ts
+++ b/src/content-hashes/application/hashDirectory.test.ts
@@ -394,7 +394,9 @@ const expected = {
 }
 
 describe('hashDirectory', () => {
-  it('hashes a directory into a registry', (done) => {
+  it('hashes a directory into a registry', function (done) {
+    this.timeout(10000)
+
     const test = doEffect(function* () {
       try {
         const registry = yield* hashDirectory(testDirectory)

--- a/src/content-hashes/defaultPlugins.ts
+++ b/src/content-hashes/defaultPlugins.ts
@@ -2,11 +2,14 @@ import {
   createCssPlugin,
   createHtmlPlugin,
   createJavascriptPlugin,
+  CssPluginOptions,
   HashPlugin,
   HtmlPuginOptions,
   JavascriptPluginOptions,
 } from './infrastructure'
 
-export function createDefaultPlugins(options: JavascriptPluginOptions & HtmlPuginOptions): readonly HashPlugin[] {
-  return [createJavascriptPlugin(options), createCssPlugin(), createHtmlPlugin(options)]
+export function createDefaultPlugins(
+  options: JavascriptPluginOptions & CssPluginOptions & HtmlPuginOptions,
+): readonly HashPlugin[] {
+  return [createJavascriptPlugin(options), createCssPlugin(options), createHtmlPlugin(options)]
 }

--- a/src/content-hashes/infrastructure/plugins/defaults.ts
+++ b/src/content-hashes/infrastructure/plugins/defaults.ts
@@ -1,0 +1,1 @@
+export const MAIN_FIELDS = ['main']

--- a/src/content-hashes/infrastructure/plugins/resolvePackage.ts
+++ b/src/content-hashes/infrastructure/plugins/resolvePackage.ts
@@ -8,7 +8,6 @@ const moduleDirectory = ['node_modules', '@types']
 const enhancedResolveOptions = {
   fileSystem: require('fs'),
   useSyncFileSystemCalls: true,
-  mainFields: ['main', 'module'],
   enforceExtension: false,
   modules: moduleDirectory,
 }
@@ -17,12 +16,14 @@ export type ResolvePackageOptions = {
   readonly moduleSpecifier: string
   readonly directory: string
   readonly extensions: readonly string[]
+  readonly mainFields: readonly string[]
 }
 
 export function resolvePackage(options: ResolvePackageOptions) {
-  const { moduleSpecifier, directory, extensions } = options
+  const { moduleSpecifier, directory, extensions, mainFields } = options
   const resolver = enhancedResolve.ResolverFactory.createResolver({
     ...enhancedResolveOptions,
+    mainFields: mainFields ? Array.from(mainFields) : void 0,
     extensions: Array.from(extensions),
   })
 


### PR DESCRIPTION
Closes #4 

This PR mainly brings in `enhanced-resolve` which is used by webpack to resolve packages which should bring in more support for resolving files. While I was doing so it seemed obvious to me that configuring mainFields is going to be something very specific to a given project, so I've gone ahead and made this a configurable value.