### PR TITLE
Still use hashed file path when specifiying baseUrl

### DIFF
--- a/src/content-hashes/infrastructure/rewriteDependencies.ts
+++ b/src/content-hashes/infrastructure/rewriteDependencies.ts
@@ -99,7 +99,7 @@ function determineReplacementPath({
   const relativePath = ensureRelative(relative(dirname(document.filePath), hashedPath))
   const absolutePath = ensureAbsolute(relative(directory, hashedPath))
   const pathToUse = baseUrl
-    ? applyOrigin(directory, dep.filePath, baseUrl)
+    ? applyOrigin(directory, hashedPath, baseUrl)
     : dep.specifier.startsWith('/')
     ? absolutePath
     : relativePath


### PR DESCRIPTION
The `applyOrigin` function is called with `dep.filePath` instead of `hashedPath`. This results in broken URLs when a `baseUrl` is specified. Using `hashedPath` resolves the issue.